### PR TITLE
Changed http to https for angular script origin

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-<script src= "http://ajax.googleapis.com/ajax/libs/angularjs/1.3.7/angular.min.js"></script>
+<script src= "https://ajax.googleapis.com/ajax/libs/angularjs/1.3.7/angular.min.js"></script>
 
 <link rel="icon" href="bus_icon.png" sizes="192x192" type="image/ico">
 


### PR DESCRIPTION
This is necessary to avoid "mixed content" errors which occur if https://johschmitz.github.io/busplan/ is used in some browsers. More information: https://developer.mozilla.org/en-US/docs/Security/Mixed_content
